### PR TITLE
Test improvements about assertion and autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,13 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "hmmmath\\": "src/"
+        "psr-4": {
+            "hmmmath\\": "src/hmmmath"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "hmmmath\\Tests\\": "tests/hmmmath/Tests"
         }
     },
     "require": {

--- a/tests/hmmmath/Tests/GreatestCommonDivisor/GreatestCommonDivisorTest.php
+++ b/tests/hmmmath/Tests/GreatestCommonDivisor/GreatestCommonDivisorTest.php
@@ -40,9 +40,9 @@ class GreatestCommonDivisorTest extends TestCase
 
     public function testINF()
     {
-        $this->assertTrue(is_infinite(GreatestCommonDivisor::greatestCommonDivisor([10, INF])));
-        $this->assertTrue(is_infinite(GreatestCommonDivisor::greatestCommonDivisor([INF, INF])));
-        $this->assertTrue(is_infinite(GreatestCommonDivisor::greatestCommonDivisor([INF, 10])));
-        $this->assertTrue(is_infinite(GreatestCommonDivisor::greatestCommonDivisor([10, INF, 10])));
+        $this->assertInfinite(GreatestCommonDivisor::greatestCommonDivisor([10, INF]));
+        $this->assertInfinite(GreatestCommonDivisor::greatestCommonDivisor([INF, INF]));
+        $this->assertInfinite(GreatestCommonDivisor::greatestCommonDivisor([INF, 10]));
+        $this->assertInfinite(GreatestCommonDivisor::greatestCommonDivisor([10, INF, 10]));
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `PSR-4` to load classes automatically because the `PSR-0` autoloading approach has been deprecated.
- Using the `assertInfinite` to assert expected type is `infinite`.